### PR TITLE
Ensure sections load before initializing app

### DIFF
--- a/js/loadSections.js
+++ b/js/loadSections.js
@@ -9,11 +9,15 @@ const sections = [
   { id: 'contact-s', file: 'sections/contact.html' }
 ];
 
-sections.forEach(section => {
+const loadPromises = sections.map(section =>
   fetch(section.file)
     .then(response => response.text())
     .then(html => {
       document.getElementById(section.id).innerHTML = html;
     })
-    .catch(error => console.error(`Error loading ${section.file}:`, error));
+    .catch(error => console.error(`Error loading ${section.file}:`, error))
+);
+
+Promise.all(loadPromises).then(() => {
+  document.dispatchEvent(new Event('sectionsLoaded'));
 });

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", function() {
+function init(){
   const idiomaPreferido = navigator.language;
   const enlaceCV = document.getElementById('cvLink');
 
@@ -23,7 +23,9 @@ document.addEventListener("DOMContentLoaded", function() {
       verticalMovement();
     }
   });
-});
+}
+
+document.addEventListener('sectionsLoaded', init);
 
 function verifyMax768pxWidth() {
   return window.matchMedia("(max-width: 768px)").matches;


### PR DESCRIPTION
## Summary
- load all HTML sections before continuing
- initialize app logic only after `sectionsLoaded` event

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877507820d4832783a2e0ad95aea948