### PR TITLE
Fix language loading after sections injection

### DIFF
--- a/js/loadSections.js
+++ b/js/loadSections.js
@@ -9,11 +9,15 @@ const sections = [
   { id: 'contact-s', file: 'sections/contact.html' }
 ];
 
-sections.forEach(section => {
-  fetch(section.file)
+const loadPromises = sections.map(section => {
+  return fetch(section.file)
     .then(response => response.text())
     .then(html => {
       document.getElementById(section.id).innerHTML = html;
     })
     .catch(error => console.error(`Error loading ${section.file}:`, error));
+});
+
+Promise.all(loadPromises).then(() => {
+  document.dispatchEvent(new Event('sectionsLoaded'));
 });

--- a/js/script.js
+++ b/js/script.js
@@ -1,14 +1,16 @@
 document.addEventListener("DOMContentLoaded", function() {
-  const idiomaPreferido = navigator.language;
-  const enlaceCV = document.getElementById('cvLink');
+  document.addEventListener('sectionsLoaded', function() {
+    const idiomaPreferido = navigator.language;
+    const enlaceCV = document.getElementById('cvLink');
 
-  // if(idiomaPreferido === "es-ES"){
-  //   enlaceCV.href = 'assets/CV_Eduardo.pdf';
-  //   loadLanguage("es");
-  // }else{
-  //   enlaceCV.href = 'assets/CV_Eduardo_En.pdf';
-  //   loadLanguage("en");
-  // }
+    if(idiomaPreferido === "es-ES"){
+      enlaceCV.href = 'assets/CV_Eduardo.pdf';
+      loadLanguage("es");
+    }else{
+      enlaceCV.href = 'assets/CV_Eduardo_En.pdf';
+      loadLanguage("en");
+    }
+  });
 
   if (verifyMax768pxWidth()) {
     horizontalMovement();

--- a/sections/welcome.html
+++ b/sections/welcome.html
@@ -21,7 +21,7 @@
       <h1>Bienvenid@ a mi Portafolio</h1>
       <p>¡Hola! Soy Eduardo García Romera, ingeniero informático y apasionado por la tecnología. Aquí encontrarás una muestra de mis proyectos y habilidades.</p>
       <div class="cv-container">
-        <a class="cv-link" href="assets/CV_Eduardo.pdf" download>
+        <a class="cv-link" id="cvLink" href="assets/CV_Eduardo.pdf" download>
           <div id="cv_text">Descargar mi CV </div><i class="fa-solid fa-file-pdf"></i>
         </a>
       </div>


### PR DESCRIPTION
## Summary
- dispatch a `sectionsLoaded` event once all sections are fetched
- hook language selection and CV link update on `sectionsLoaded`
- add `cvLink` id to the CV anchor so it can be updated dynamically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877509660708327bcd7e65abfee73a5